### PR TITLE
feat(npm): Rename project to get rid of v2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,13 +1,15 @@
-# ng2-http-interceptor
+# ng-http-interceptor
 
-> Http Interceptor library for Angular 2
+> Http Interceptor library for Angular
 
-[![Travis CI](https://img.shields.io/travis/gund/ng2-http-interceptor/master.svg?maxAge=2592000)](https://travis-ci.org/gund/ng2-http-interceptor)
-[![Coverage](https://img.shields.io/codecov/c/github/gund/ng2-http-interceptor.svg?maxAge=2592000)](https://codecov.io/gh/gund/ng2-http-interceptor)
-[![Code Climate](https://img.shields.io/codeclimate/github/gund/ng2-http-interceptor.svg?maxAge=2592000)](https://codeclimate.com/github/gund/ng2-http-interceptor)
-[![Npm](https://img.shields.io/npm/v/ng2-http-interceptor.svg?maxAge=2592000)](https://badge.fury.io/js/ng2-http-interceptor)
-[![Npm Downloads](https://img.shields.io/npm/dt/ng2-http-interceptor.svg?maxAge=2592000)](https://www.npmjs.com/package/ng2-http-interceptor)
-[![Licence](https://img.shields.io/npm/l/ng2-http-interceptor.svg?maxAge=2592000)](https://github.com/gund/ng2-http-interceptor/blob/master/LICENSE)
+*Previously was called `ng2-http-interceptor`*
+
+[![Travis CI](https://img.shields.io/travis/gund/ng-http-interceptor/master.svg?maxAge=2592000)](https://travis-ci.org/gund/ng-http-interceptor)
+[![Coverage](https://img.shields.io/codecov/c/github/gund/ng-http-interceptor.svg?maxAge=2592000)](https://codecov.io/gh/gund/ng-http-interceptor)
+[![Code Climate](https://img.shields.io/codeclimate/github/gund/ng-http-interceptor.svg?maxAge=2592000)](https://codeclimate.com/github/gund/ng-http-interceptor)
+[![Npm](https://img.shields.io/npm/v/ng-http-interceptor.svg?maxAge=2592000)](https://badge.fury.io/js/ng-http-interceptor)
+[![Npm Downloads](https://img.shields.io/npm/dt/ng-http-interceptor.svg?maxAge=2592000)](https://www.npmjs.com/package/ng-http-interceptor)
+[![Licence](https://img.shields.io/npm/l/ng-http-interceptor.svg?maxAge=2592000)](https://github.com/gund/ng-http-interceptor/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Features
@@ -49,7 +51,7 @@ Please make sure that you are importing `ts-helpers` module in your application.
 To install this library, run:
 
 ```bash
-$ npm install ng2-http-interceptor --save
+$ npm install ng-http-interceptor --save
 ```
 
 ## Usage

--- a/e2e/demo/config.js
+++ b/e2e/demo/config.js
@@ -12,7 +12,7 @@ System.config({
   map: {
     
     'app': './src',
-    'ng2-http-interceptor': './dist/bundles/ng2-http-interceptor.umd.js',
+    'ng2-http-interceptor': './dist/bundles/ng-http-interceptor.umd.js',
     
     '@angular/core': 'npm:@angular/core/bundles/core.umd.js',
     '@angular/common': 'npm:@angular/common/bundles/common.umd.js',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng2-http-interceptor",
+  "name": "ng-http-interceptor",
   "version": "0.0.0-semantically-relesed",
   "scripts": {
     "prebuild": "rimraf dist compiled",
@@ -7,7 +7,7 @@
     "build:main": "ngc -p tsconfig.aot.json",
     "postbuild:main": "npm run build:umd",
     "build:umd": "rollup -c rollup.config.js",
-    "postbuild:umd": "uglifyjs -c --screw-ie8 --comments -o dist/bundles/ng2-http-interceptor.umd.min.js dist/bundles/ng2-http-interceptor.umd.js",
+    "postbuild:umd": "uglifyjs -c --screw-ie8 --comments -o dist/bundles/ng-http-interceptor.umd.min.js dist/bundles/ng-http-interceptor.umd.js",
     "check-coverage": "istanbul check-coverage --functions 75 --lines 75 --branches 75 --statements 75",
     "ci": "npm run lint && npm run test:single && npm run check-coverage",
     "commit": "git-cz",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gund/ng2-http-interceptor"
+    "url": "https://github.com/gund/ng-http-interceptor"
   },
   "author": {
     "name": "Alex Malkevich",
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/gund/ng2-http-interceptor/issues"
+    "url": "https://github.com/gund/ng-http-interceptor/issues"
   },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 export default {
     entry: 'dist/index.js',
-    dest: 'dist/bundles/ng2-http-interceptor.umd.js',
+    dest: 'dist/bundles/ng-http-interceptor.umd.js',
     format: 'umd',
     moduleName: 'httpInterceptor',
     globals: {


### PR DESCRIPTION
BREAKING CHANGE: npm module renamed to ng-http-interceptor. Closes #105