### PR TITLE
feat(npm): Rename project to get rid of v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "keywords": [
     "ng",
+    "ng2",
     "angular",
     "angular2",
     "http",


### PR DESCRIPTION
BREAKING CHANGE: npm module renamed to ng-http-interceptor. Closes #105